### PR TITLE
Bump agents endpoint version

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -28,7 +28,7 @@ func (c *DefaultClient) GetAllAgents() ([]*Agent, error) {
 
 	_, body, errs := c.Request.
 		Get(c.resolve("/go/api/agents")).
-		Set("Accept", "application/vnd.go.cd.v2+json").
+		Set("Accept", "application/vnd.go.cd.v4+json").
 		End()
 	if errs != nil {
 		errors = multierror.Append(errors, errs...)

--- a/agent_test.go
+++ b/agent_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetAllAgents(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 2, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 4, DummyRequestBodyValidator))
 	defer server.Close()
 	agents, err := client.GetAllAgents()
 	assert.NoError(t, err)


### PR DESCRIPTION
Tested with 18.6.0.
Without this, there would be an empty result.