### PR TITLE
AgentRunJobHistory should return JobHistory and Pagination

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -162,26 +162,9 @@ func (c *DefaultClient) DeleteAgent(uuid string) error {
 }
 
 // AgentRunJobHistory - Lists the jobs that have executed on an agent.
-func (c *DefaultClient) AgentRunJobHistory(uuid string, offset int) ([]*JobHistory, error) {
-	var errors *multierror.Error
-	_, body, errs := c.Request.
-		Get(c.resolve(fmt.Sprintf("/go/api/agents/%s/job_run_history/%d", uuid, offset))).
-		// 18.6.0: providing API version here results in "resource not found"
-		Set("Accept", "application/json").
-		End()
-	if errs != nil {
-		errors = multierror.Append(errors, errs...)
-		return []*JobHistory{}, errors.ErrorOrNil()
-	}
-
-	type JobHistoryResponse struct {
-		Jobs []*JobHistory `json:"jobs"`
-	}
-	var jobs *JobHistoryResponse
-	jsonErr := json.Unmarshal([]byte(body), &jobs)
-	if jsonErr != nil {
-		errors = multierror.Append(errors, jsonErr)
-		return []*JobHistory{}, errors.ErrorOrNil()
-	}
-	return jobs.Jobs, errors.ErrorOrNil()
+func (c *DefaultClient) AgentRunJobHistory(uuid string, offset int) (*JobRunHistory, error) {
+	res := new(JobRunHistory)
+	headers := map[string]string{"Accept": "application/json"}
+	err := c.getJSON(fmt.Sprintf("/go/api/agents/%s/job_run_history/%d", uuid, offset), headers, res)
+	return res, err
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -84,8 +84,9 @@ func TestAgentRunHistory(t *testing.T) {
 
 	client, server := newTestAPIClient("/go/api/agents/uuid/job_run_history/0", serveFileAsJSON(t, "GET", "test-fixtures/get_agent_run_history.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
-	jobs, err := client.AgentRunJobHistory("uuid", 0)
+	history, err := client.AgentRunJobHistory("uuid", 0)
 	assert.NoError(t, err)
+	jobs := history.Jobs
 	assert.NotNil(t, jobs)
 	assert.Equal(t, 1, len(jobs))
 	job1 := jobs[0]
@@ -107,6 +108,11 @@ func TestAgentRunHistory(t *testing.T) {
 	assert.Equal(t, 100129, job1.ID)
 	assert.Equal(t, "1", job1.StageCounter)
 	assert.Equal(t, "upload-installers", job1.StageName)
+
+	pagination := history.Pagination
+	assert.Equal(t, pagination.Total, 1292)
+	assert.Equal(t, pagination.Offset, 0)
+	assert.Equal(t, pagination.PageSize, 10)
 }
 
 func TestFreeSpace(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ type Client interface {
 	DisableAgent(uuid string) error
 	EnableAgent(uuid string) error
 	DeleteAgent(uuid string) error
-	AgentRunJobHistory(uuid string, offset int) ([]*JobHistory, error)
+	AgentRunJobHistory(uuid string, offset int) (*JobRunHistory, error)
 
 	// Pipeline Groups API
 	GetPipelineGroups() ([]*PipelineGroup, error)

--- a/jobs.go
+++ b/jobs.go
@@ -102,6 +102,11 @@ type JobStateTransition struct {
 	State           string `json:"state,omitempty"`
 }
 
+type JobRunHistory struct {
+	Jobs       []*JobHistory `json:"jobs"`
+	Pagination Pagination    `json:"pagination"`
+}
+
 // GetJobHistory - The job history allows users to list job instances of specified job. Supports pagination using offset which tells the API how many instances to skip.
 func (c *DefaultClient) GetJobHistory(pipeline, stage, job string, offset int) ([]*JobHistory, error) {
 	var errors *multierror.Error


### PR DESCRIPTION
Added JobRunHistory struct to include both JobHistory and Pagination in
AgentRunJobHistory.