### PR TITLE
Use v6 of the Agents API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ setup:
 	go get github.com/stretchr/testify
 
 test:
-	go test -v github.com/ashwanthkumar/go-gocd
+	go test -v github.com/pagero/go-gocd-1

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ setup:
 	go get github.com/stretchr/testify
 
 test:
-	go test -v github.com/pagero/go-gocd-1
+	go test -v github.com/pagero/go-gocd-ashwanth

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-gocd
+# go-gocd-ashwanth
 
 Go Lang library to access [GoCD API](https://api.go.cd/current/).
 
@@ -7,7 +7,7 @@ Go Lang library to access [GoCD API](https://api.go.cd/current/).
 package main
 
 import (
-  "github.com/pagero/go-gocd-1"
+  "github.com/pagero/go-gocd-ashwanth"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://snap-ci.com/ashwanthkumar/go-gocd/branch/master/build_image)](https://snap-ci.com/ashwanthkumar/go-gocd/branch/master) [![GoDoc](https://godoc.org/github.com/ashwanthkumar/go-gocd?status.svg)](https://godoc.org/github.com/ashwanthkumar/go-gocd)
-
 # go-gocd
 
 Go Lang library to access [GoCD API](https://api.go.cd/current/).
@@ -9,7 +7,7 @@ Go Lang library to access [GoCD API](https://api.go.cd/current/).
 package main
 
 import (
-  "github.com/ashwanthkumar/go-gocd"
+  "github.com/pagero/go-gocd-1"
 )
 
 func main() {

--- a/agent.go
+++ b/agent.go
@@ -58,7 +58,7 @@ func (c *DefaultClient) GetAllAgents() ([]*Agent, error) {
 
 	_, body, errs := c.Request.
 		Get(c.resolve("/go/api/agents")).
-		Set("Accept", "application/vnd.go.cd.v4+json").
+		Set("Accept", "application/vnd.go.cd.v6+json").
 		End()
 	if errs != nil {
 		errors = multierror.Append(errors, errs...)
@@ -87,7 +87,7 @@ func (c *DefaultClient) GetAgent(uuid string) (*Agent, error) {
 
 	_, body, errs := c.Request.
 		Get(c.resolve(fmt.Sprintf("/go/api/agents/%s", uuid))).
-		Set("Accept", "application/vnd.go.cd.v4+json").
+		Set("Accept", "application/vnd.go.cd.v6+json").
 		End()
 	errors = multierror.Append(errors, errs...)
 	if errs != nil {
@@ -110,7 +110,7 @@ func (c *DefaultClient) UpdateAgent(uuid string, agent *Agent) (*Agent, error) {
 
 	_, body, errs := c.Request.
 		Patch(c.resolve(fmt.Sprintf("/go/api/agents/%s", uuid))).
-		Set("Accept", "application/vnd.go.cd.v4+json").
+		Set("Accept", "application/vnd.go.cd.v6+json").
 		SendStruct(agent).
 		End()
 	multierror.Append(errors, errs...)
@@ -153,7 +153,7 @@ func (c *DefaultClient) DeleteAgent(uuid string) error {
 
 	_, _, errs := c.Request.
 		Delete(c.resolve(fmt.Sprintf("/go/api/agents/%s", uuid))).
-		Set("Accept", "application/vnd.go.cd.v4+json").
+		Set("Accept", "application/vnd.go.cd.v6+json").
 		End()
 	if len(errs) > 0 {
 		errors = multierror.Append(errors, errs...)

--- a/agent_test.go
+++ b/agent_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGetAllAgents(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 4, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 6, DummyRequestBodyValidator))
 	defer server.Close()
 	agents, err := client.GetAllAgents()
 	assert.NoError(t, err)
@@ -32,7 +32,7 @@ func TestGetAllAgents(t *testing.T) {
 
 func TestGetAgent(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "GET", "test-fixtures/get_agent.json", 4, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "GET", "test-fixtures/get_agent.json", 6, DummyRequestBodyValidator))
 	defer server.Close()
 	agent, err := client.GetAgent("uuid")
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestUpdateAgent(t *testing.T) {
 		return nil
 	}
 
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "PATCH", "test-fixtures/patch_agent.json", 4, requestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "PATCH", "test-fixtures/patch_agent.json", 6, requestBodyValidator))
 	defer server.Close()
 	var agent = Agent{
 		Hostname: "agent02.example.com",
@@ -73,7 +73,7 @@ func TestUpdateAgent(t *testing.T) {
 func TestDeleteAgent(t *testing.T) {
 	t.Parallel()
 
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "DELETE", "test-fixtures/delete_agent.json", 4, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "DELETE", "test-fixtures/delete_agent.json", 6, DummyRequestBodyValidator))
 	defer server.Close()
 	err := client.DeleteAgent("uuid")
 	assert.NoError(t, err)

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package gocd_test
 import (
 	"fmt"
 
-	"github.com/pagero/go-gocd-1"
+	"github.com/pagero/go-gocd-ashwanth"
 )
 
 // ExampleDefaultClient_GetPipelineInstance displays an instance of a pipeline

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package gocd_test
 import (
 	"fmt"
 
-	"github.com/ashwanthkumar/go-gocd"
+	"github.com/pagero/go-gocd-1"
 )
 
 // ExampleDefaultClient_GetPipelineInstance displays an instance of a pipeline

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/pagero/go-gocd-1"
+import "github.com/pagero/go-gocd-ashwanth"
 import "github.com/stretchr/testify/mock"
 
 type Client struct {

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/ashwanthkumar/go-gocd"
+import "github.com/pagero/go-gocd-1"
 import "github.com/stretchr/testify/mock"
 
 type Client struct {


### PR DESCRIPTION
Version 6 of the Agents API was introduced and is required in GoCD 19.9.0.

See https://api.gocd.org/19.9.0/#agents